### PR TITLE
Add polling tools callout

### DIFF
--- a/episodes/lifecycle.Rmd
+++ b/episodes/lifecycle.Rmd
@@ -293,6 +293,15 @@ tar_dir({
 })
 ```
 
+::: callout
+
+Targets also offers some dynamic monitoring tools that you can leave running to monitor long pipelines:
+
+* [`tar_poll`](https://docs.ropensci.org/targets/reference/tar_poll.html) gives a ongoing progress summary in the R terminal
+* [`tar_watch`](https://docs.ropensci.org/targets/reference/tar_watch.html) starts a Shiny app that shows the current output of `tar_visnetwork`
+
+:::
+
 ## Granular control of targets
 
 It is possible to only make a particular target instead of running the entire workflow.


### PR DESCRIPTION
Just added a quick reference to some dynamic/ongoing status polling tools for long running pipelines. It looks like this:

![image](https://github.com/carpentries-incubator/targets-workshop/assets/5019367/9232c5f7-20d0-468b-b2cd-722ca0fe0b73)

I don't mind if this PR is accepted or not, it's just something I will be including in my fork of the repo when I present this.
