### PR TITLE
More on `::` briefly in packages.Rmd

### DIFF
--- a/episodes/packages.Rmd
+++ b/episodes/packages.Rmd
@@ -215,7 +215,9 @@ As you may imagine, this can cause confusion.
 For example, the `filter()` function appears in both the `stats` package and the `dplyr` package, but does completely different things in each.
 This is a **namespace conflict**: how do we know which `filter()` we are talking about?
 
-The `conflicted` package can help prevent such confusion by stopping you if you try to use an ambiguous function, and help you be explicit about which package to use.
+One solution we have covered already is using the `::` notation when calling functions. This is because writing `dplyr::filter()` specifies that you are using `filter()` from the `dplyr` namespace. The tradeoff to this approach is verbosity, meaning more typing and reading. 
+
+An alternative to `::` is to use the `conflicted` package. It can help prevent confusion by stopping you if you try to use an ambiguous function, and help you be explicit about which package to use.
 We don't have time to cover the details here, but you can read more about how to use `conflicted` at its [website](https://conflicted.r-lib.org/).
 
 When you use `conflicted`, you will typically run a series of commands to explicitly resolve namespace conflicts, like `conflicts_prefer(dplyr::filter)` (this would tell R that we want to use `filter` from `dplyr`, not `stats`).


### PR DESCRIPTION
Hey @joelnitta , as requested moving this (now pretty old, sorry!) PR from your fork to the base repo.

Because it is one of the fundamental benefits of the operator, I thought it would be worth putting in a little bit that explains `::` can be used to prevent namespace conflicts. It seems reasonable, because I think novice R users could otherwise believe that using `conflicted` is the only way to work. But this is just a suggestion.